### PR TITLE
Update p5.c

### DIFF
--- a/p5/p5.c
+++ b/p5/p5.c
@@ -1,6 +1,6 @@
 #include "p5.h"
 #include<stdlib.h>
-
+/* dummy: remove comment when modifying */
 int main(void)
 {
     size_t *result = (size_t*)malloc(sizeof(size_t));


### PR DESCRIPTION
int serialize_data(COMPONENT_DATA* component_info, void* serialization_buffer, size_t buffer_size, size_t *result)

result => in/out parameter => update doxygen
Seems that you are allocating it on heap in main . Can you think of another way of passing the value to the function ?

A good practice is too check the input parameters when entering a function . What would happen if by mistake the caller calls the function
 with a NULL buffer/struct ?
 
int deserialize_data(void *serialization_buffer, size_t buffer_size, COMPONENT_DATA* component_info, size_t *result)
==>> same ==>> check again the doxygen comment, what does the return mean here(the deserialize_size seems to remain 0 in case of failure). 
 
serialization_buffer ==>> is still a pointer(line 138)
 
line 120 ==>> if previously the size was checked, the size has to be checked here as well