### PR TITLE
Update main2.c

### DIFF
--- a/p7/main2.c
+++ b/p7/main2.c
@@ -8,7 +8,7 @@
  * https://docs.oracle.com/cd/E88353_01/html/E37843/dlsym-3c.html
  * https://stackoverflow.com/questions/1354537/dlsym-dlopen-with-runtime-arguments
  */
-
+/*remove dummy line*/
 int main(void)
 {
     void *handle = dlopen("/home/uic84214/bootcamp/p7/libsample.so", RTLD_LOCAL | RTLD_LAZY);


### PR DESCRIPTION
alloc_in_lib ==> just allocate pointer to heap, no need to read/assign value
             ==> check malloc return value and return NULL if NOK
			 ==> printfs are not relevant at the beggining, just print in case of malloc error or success
free_in_lib ==>> doxygen :) ,check input value and if NULL print error message.

main.c  => be consistent with the print functions and give the value to the allocated pointer here
main2.c => check dlerror function and use it appropriately

lines 46-49 => you are correct for the functions, but why ? what does dlsym/dlclose do ?(check man page) https://linux.die.net/man/3/dlclose